### PR TITLE
[14.0][IMP] product_configurator_mrp (Set BoM Sequences)

### DIFF
--- a/product_configurator_mrp/models/mrp.py
+++ b/product_configurator_mrp/models/mrp.py
@@ -56,6 +56,21 @@ class MrpBom(models.Model):
         readonly=True,
     )
 
+    def set_bom_sequences(self, product_tmpl_id=None):
+        # Set BoM Sequences. For MO, Odoo will look for the first BoM to use, which is
+        # usually the Master BoM without a variant. Setting the Master BoM sequence
+        # higher will ensure Odoo doesn't use the master BoM when it should use
+        # variant's BoM
+        related_boms = self.env["mrp.bom"].search(
+            [("product_tmpl_id", "=", product_tmpl_id.id)]
+        )
+        if related_boms:
+            for bom in related_boms:
+                if bom.product_id and bom.sequence == 0:
+                    bom.write({"sequence": 1})
+                elif not bom.product_id:
+                    bom.write({"sequence": len(related_boms)})
+
 
 class MrpBomLine(models.Model):
     _inherit = "mrp.bom.line"

--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -122,6 +122,7 @@ class ProductConfigSession(models.Model):
             if mrp_bom_id and parent_bom:
                 for operation_line in parent_bom.operation_ids:
                     operation_line.copy(default={"bom_id": mrp_bom_id.id})
+            mrp_bom_id.set_bom_sequences(mrp_bom_id.product_tmpl_id)
             return mrp_bom_id
         return False
 

--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -121,7 +121,9 @@ class ProductConfigSession(models.Model):
             mrp_bom_id = mrpBom.create(values)
             if mrp_bom_id and parent_bom:
                 for operation_line in parent_bom.operation_ids:
-                    operation_line.copy(default={"bom_id": mrp_bom_id.id})
+                    new_op = operation_line.copy(default={"bom_id": mrp_bom_id.id})
+                    for step in new_op.quality_point_ids:
+                        step.write({"product_ids": [(6, 0, [variant.id])]})
             mrp_bom_id.set_bom_sequences(mrp_bom_id.product_tmpl_id)
             return mrp_bom_id
         return False


### PR DESCRIPTION
This fix is originally by Patrick Wilson. As this is not a fork from the OCA repo I had to copy and paste the code on this new branch to apply it. Please refer to his commit/PR in the OCA repo and his original description of the change below:

https://github.com/OCA/product-configurator/pull/80

Sets sequences on the BoM so proper BoM is used on the MO.
When the variant is created by the configurator, so is it's BoM however the BoM sequences typically aren't set. So, when Odoo creates an MO, it looks through the BoM's of the related product template and uses the first one it finds either one with the product variant or without any variants.

If the main BoM (aka Master BoM) is found first, it will be used instead of the variant's BoM since it doesn't have a variant applied to it.

Setting the sequences and making the BoM's without variants have a high sequence resolves this issue.