### PR TITLE
[FIX] Do not add new bom line if one exists for product_id already

### DIFF
--- a/product_configurator_mrp_component/models/product_config.py
+++ b/product_configurator_mrp_component/models/product_config.py
@@ -68,7 +68,6 @@ class ProductConfigSession(models.Model):
                     [
                         ("bom_id", "=", master_bom.id),
                         ("product_id", "=", component_config_session.product_id.id),
-                        ("config_set_id", "=", bom_line_config_set.id),
                     ],
                     limit=1,
                 )
@@ -79,6 +78,12 @@ class ProductConfigSession(models.Model):
                             "product_id": component_variant.id,
                             "config_set_id": bom_line_config_set.id,
                             "product_qty": config_component_line.product_qty,
+                        }
+                    )
+                else:
+                    existing_bom_line.update(
+                        {
+                            "config_set_id": bom_line_config_set.id,
                         }
                     )
         return super().create_get_bom(variant, product_tmpl_id=None, values=None)


### PR DESCRIPTION
Ticket: [Updated Variant SKU > Duplicated BOM Config Sets (#41309)](https://pm.opensourceintegrators.com/web#id=41309&cids=1&menu_id=218&action=1093&model=helpdesk.ticket&view_type=form)

Resolves issue where updating a variant's internal reference then adding that variant to a SO using the product configurator adds a new line on the master BoM with a new Config Set with the updated display name of the variant. If a line for that product_id already exists on teh master BoM, it will instead update the existing line's Config Set with the new one rather than creating a new line. 