### PR TITLE
[FIX] Potential Wrong UoM used for component on newly created boms

### DIFF
--- a/product_configurator_mrp/models/product_config.py
+++ b/product_configurator_mrp/models/product_config.py
@@ -99,7 +99,7 @@ class ProductConfigSession(models.Model):
                     )
                     values2 = updates.get("value", {})
                     values2 = self.get_vals_to_write(
-                        values=values, model="mrp.bom.line"
+                        values=values2, model="mrp.bom.line"
                     )
                     values2.update(parent_bom_line_vals)
                     bom_lines.append((0, 0, values2))


### PR DESCRIPTION
Ticket: [Ska Fabricating - Odoo User Error (#45429)](https://pm.opensourceintegrators.com/web#id=45429&menu_id=218&cids=1&action=1093&model=helpdesk.ticket&view_type=form)

Wrong values were being passed int the following method call. I twould use the values created by prior parts of the code and not the values2 it generates in this block. This can lead to a case where the wrong UoM is used as it pulls it from the wrong product.