### PR TITLE
[IMP]product_configurator_restriction_policy

### DIFF
--- a/product_configurator_restriction_policy/models/product_config.py
+++ b/product_configurator_restriction_policy/models/product_config.py
@@ -9,7 +9,7 @@ class ProductConfigSession(models.Model):
 
     @api.model
     def values_available(
-        self, check_val_ids=None, value_ids=None, custom_vals=None, product_tmpl_id=None
+        self, check_val_ids=None, value_ids=None, custom_vals=None, product_tmpl_id=None, product_template_attribute_line_id=None
     ):
         """Overrides product configurator values_available to include
         the restriction policy option while generating available values"""


### PR DESCRIPTION
Applies fix from another client's repo for issues regarding restriction policies causing incorrect values to be displayed in selection boxes on the configurator wizard

Ticket: [55491](https://pm.opensourceintegrators.com/web#id=55491&cids=1&menu_id=218&action=324&model=helpdesk.ticket&view_type=form)